### PR TITLE
Feat: Issue #37: Refactor WordBoggle::getNeighbors

### DIFF
--- a/Java/src/main/java/com/thealgorithms/misc/WordBoggle.java
+++ b/Java/src/main/java/com/thealgorithms/misc/WordBoggle.java
@@ -85,39 +85,19 @@ public class WordBoggle {
 
     public static List<Integer[]> getNeighbors(int i, int j, char[][] board) {
         List<Integer[]> neighbors = new ArrayList<>();
-        if (i > 0 && j > 0) {
-            neighbors.add(new Integer[]{i - 1, j - 1});
-        }
 
-        if (i > 0 && j < board[0].length - 1) {
-            neighbors.add(new Integer[]{i - 1, j + 1});
+        for (int x = -1; x <= 1; x++) {
+            for (int y = -1; y <= 1; y++) {
+                if ((x == 0 && y == 0) || !isInBounds(i+x, j+y, board.length, board[0].length))
+                    continue;
+                neighbors.add(new Integer[]{i + x, j + y});
+            }
         }
-
-        if (i < board.length - 1 && j < board[0].length - 1) {
-            neighbors.add(new Integer[]{i + 1, j + 1});
-        }
-
-        if (i < board.length - 1 && j > 0) {
-            neighbors.add(new Integer[]{i + 1, j - 1});
-        }
-
-        if (i > 0) {
-            neighbors.add(new Integer[]{i - 1, j});
-        }
-
-        if (i < board.length - 1) {
-            neighbors.add(new Integer[]{i + 1, j});
-        }
-
-        if (j > 0) {
-            neighbors.add(new Integer[]{i, j - 1});
-        }
-
-        if (j < board[0].length - 1) {
-            neighbors.add(new Integer[]{i, j + 1});
-        }
-
         return neighbors;
+    }
+
+    private static boolean isInBounds(int i, int j, int iMax, int jMax) {
+        return !(i < 0 || i >= iMax || j < 0 || j >= jMax);
     }
 }
 

--- a/report.md
+++ b/report.md
@@ -283,13 +283,37 @@ cover the different possible outcomes when executing different branches.
 
 ## Refactoring
 
-Plan for refactoring complex code:
+> Plan for refactoring complex code:
 
-Estimated impact of refactoring (lower CC, but other drawbacks?).
+#### WordBoggle::getNeighbors
+> Plan for refactoring complex code:
 
-Carried out refactoring (optional, P+):
+The method WordBoggle::getNeighbors returns a list of points. This is done currently with a long chain of checking that
+the first part of the coordinate is not smaller than zero, and the second part is not smaller than zero, and if the
+first is not smaller than zero, and the second is not greater than max, and ... In short, it is very verbose.
 
-git diff ...
+This could be rewritten by letting two variables loop from -1 ..  1 in nested loops, and adding these onto the
+coordinate, and then checking if it is valid. A helper method for checking validity of a coordinate could further
+offload CC from the bit method.
+
+> Estimated impact of refactoring (lower CC, but other drawbacks?).
+
+The CC of the method should, of course, be lowered. The getNeighbors method has to check for a lot of edge cases
+depending on whether the provided coordinates lie on a  top, bottom, left or right edge of the board, whether they lie
+in a corner, et.c. Thus, it is our opinion that the  current, relatively high, complexity "makes sense". Rewriting the
+method with a loop could hurt readability somewhat, but it will probably make the method a bit shorter. Nested loops
+could also be harder to reason about than loop free code, even if the CCN is lower.
+
+> Carried out refactoring (optional, P+):
+
+The refactoring was successful, and passes our test suite. It was done more or less exactly as stated above. Without
+the helper method the CC was reduced by less than 35%, so it was necessary to add it.
+
+In the end, `getNeighbors` had its CCN reduced from 13 to 6, and a helper method `isInBounds` with a CCN of 4 was added.
+
+> git diff ...
+
+The refactoring diff can be seen [here](https://github.com/Fundamentals-KTH-CSC-2022-P3/code-complexity/commit/dee6088a9dd0044cf92e1c219787758c2c640efe).
 
 ## Coverage
 

--- a/report.md
+++ b/report.md
@@ -283,8 +283,6 @@ cover the different possible outcomes when executing different branches.
 
 ## Refactoring
 
-> Plan for refactoring complex code:
-
 #### WordBoggle::getNeighbors
 > Plan for refactoring complex code:
 
@@ -310,6 +308,7 @@ The refactoring was successful, and passes our test suite. It was done more or l
 the helper method the CC was reduced by less than 35%, so it was necessary to add it.
 
 In the end, `getNeighbors` had its CCN reduced from 13 to 6, and a helper method `isInBounds` with a CCN of 4 was added.
+A reduction from 13 to 6 is a reduction by 54%.
 
 > git diff ...
 


### PR DESCRIPTION
This PR adds a refactoring plan for WordBoggle::getNeighbors, as well as an implementation of that plan.

This results in a 54% reduction of the CCN of the method, as measured by Lizard.

Even though the tests are not present on this branch, I manually added them without commiting to test the functionality. The tests for 100% BC of getNeighbors all pass this new implementation.

Closes #37 